### PR TITLE
Componente m-button > text e refatoração

### DIFF
--- a/docs/navbar.md
+++ b/docs/navbar.md
@@ -32,6 +32,24 @@ O `m-navbar` é o componente de navegação horizontal do Macaw.
 </style>
 <m-navbar></m-navbar>
 
+<m-navbar>
+  <m-navbar-item active="true">
+    <a href="index.html">Link 1</a>
+  </m-navbar-item>
+  <m-navbar-item>
+    <a href="index.html">Link 2</a>
+  </m-navbar-item>
+  <m-navbar-item>
+    <a href="index.html">Link 3</a>
+  </m-navbar-item>
+  <m-navbar-item>
+    <a href="index.html">Link 4</a>
+  </m-navbar-item>
+  <m-navbar-item>
+    <a href="index.html">Link 5</a>
+  </m-navbar-item>
+</m-navbar>
+
 <script>
     const myNavbarInsideHeader = document.querySelector('m-navbar');
     myNavbarInsideHeader.navItems = ['<a href="index.html">Link 1</a>', '<a href="index.html">Link 2</a>','<a href="index.html">Link 3</a>', '<a href="index.html">Link 4</a>'];

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -29,12 +29,28 @@ export namespace Components {
           * Button tooltip
          */
         "tooltip": string;
+        /**
+          * Button type. "text" or "primary"
+         */
+        "type": string;
     }
     interface MDropdown {
+        /**
+          * The logged user's avatar image URL or user name.
+         */
+        "avatarSource": string;
         /**
           * Dropdown label
          */
         "label": string;
+        /**
+          * Weither to display the chevron icon or not
+         */
+        "showChevron": boolean;
+        /**
+          * Dropdown button type. "text" or "primary"
+         */
+        "type": string;
     }
     interface MDropdownItem {
     }
@@ -260,12 +276,28 @@ declare namespace LocalJSX {
           * Button tooltip
          */
         "tooltip"?: string;
+        /**
+          * Button type. "text" or "primary"
+         */
+        "type"?: string;
     }
     interface MDropdown {
+        /**
+          * The logged user's avatar image URL or user name.
+         */
+        "avatarSource"?: string;
         /**
           * Dropdown label
          */
         "label"?: string;
+        /**
+          * Weither to display the chevron icon or not
+         */
+        "showChevron"?: boolean;
+        /**
+          * Dropdown button type. "text" or "primary"
+         */
+        "type"?: string;
     }
     interface MDropdownItem {
     }

--- a/src/components/m-button/m-button.scss
+++ b/src/components/m-button/m-button.scss
@@ -1,33 +1,34 @@
-button {
-  background: $primary-color;
+.m-button {
   border: none;
-  border-radius: 4px;
-  color: $white;
   cursor: pointer;
   font-weight: 700;
   font-size: 14px;
   padding: 8px 12px;
-  transition: background-color 0.3s;
-
-  &:hover {
-    background-color: darken($primary-color, 10%);
-  }
 
   &:disabled {
     cursor: default;
     opacity: 0.5;
+    pointer-events: none;
+  }
+
+  &--text {
+    background-color: transparent;
+    color: $light-gray;
+    transition: color 0.3s;
 
     &:hover {
-      background: $primary-color;
+      color: $orange;
     }
   }
 
-  // .m-icon {
-  //   padding: 0 5px;
-  // }
+  &--primary {
+    background: $primary-color;
+    border-radius: 4px;
+    color: $white;
+    transition: background-color 0.3s;
 
-  // > * + m-icon,
-  // > m-icon + * {
-  //   padding-left: 5px;
-  // }
+    &:hover {
+      background-color: darken($primary-color, 10%);
+    }
+  }
 }

--- a/src/components/m-button/m-button.tsx
+++ b/src/components/m-button/m-button.tsx
@@ -8,6 +8,10 @@ import { Component, Prop, h, Listen, Method } from '@stencil/core';
 export class Button {
 
   /**
+   * Button type. "text" or "primary"
+   */
+  @Prop({ reflect: true }) type: string = 'primary';
+  /**
    * Button tooltip
    */
   @Prop({ attribute: 'title' }) tooltip: string;
@@ -37,7 +41,12 @@ export class Button {
 
   render() {
     return (
-      <button title={this.tooltip} disabled={this.disabled}><slot /></button>
+      <button
+        title={this.tooltip}
+        disabled={this.disabled}
+        class={'m-button m-button--' + this.type}>
+          <slot />
+      </button>
     );
   }
 }

--- a/src/components/m-dropdown/m-dropdown.scss
+++ b/src/components/m-dropdown/m-dropdown.scss
@@ -1,4 +1,5 @@
 .m-dropdown {
+  display: inline-block;
   position: relative;
 
   &__content {
@@ -13,6 +14,7 @@
 
     &--show {
       display: block;
+      width: max-content;
     }
   }
 

--- a/src/components/m-dropdown/m-dropdown.tsx
+++ b/src/components/m-dropdown/m-dropdown.tsx
@@ -8,10 +8,28 @@ import { Component, Prop, State, h } from '@stencil/core';
 export class Dropdown {
 
   /**
+   * The logged user's avatar image URL or user name.
+   */
+  @Prop() avatarSource: string;
+
+  /**
+   * Weither to display the chevron icon or not
+   */
+  @Prop({ mutable: true }) showChevron: boolean = true;
+
+  /**
+   * Dropdown button type. "text" or "primary"
+   */
+  @Prop({ reflect: true }) type: string = 'primary';
+
+  /**
    * Dropdown label
    */
   @Prop({ attribute: 'label' }) label: string;
 
+  /**
+   * Weither if the dropdown is open or not
+   */
   @State() open: boolean;
 
   handleClick() {
@@ -21,8 +39,10 @@ export class Dropdown {
   render() {
     return (
       <div class="m-dropdown">
-        <m-button onClick={() => this.handleClick()}>
-          {this.label}  <m-icon name="chevron-bottom" class={'icon ' + (this.open ? '' : 'icon--closed')} />
+        <m-button type={this.type} onClick={() => this.handleClick()}>
+          {this.avatarSource ? <m-avatar source={this.avatarSource} ></m-avatar> : ""}
+          {this.label} 
+          {this.showChevron ?  <m-icon name="chevron-bottom" class={'icon ' + (this.open ? '' : 'icon--closed')} /> : ""}
         </m-button>
         <div class={'m-dropdown__content ' + (this.open ? 'm-dropdown__content--show' : '')}>
           <ul class="list-items" onClick={() => this.handleClick()}>

--- a/src/index.html
+++ b/src/index.html
@@ -116,6 +116,15 @@
         <a href="http://">Second Item <m-icon name="check" /></a>
       </m-dropdown-item>
     </m-dropdown>
+    
+    <m-dropdown type="text" avatar-source="https://cms.qz.com/wp-content/uploads/2018/12/earring2.png" show-chevron="false">
+      <m-dropdown-item>
+        First Item
+      </m-dropdown-item>
+      <m-dropdown-item>
+        <a href="http://">Second Item <m-icon name="check" /></a>
+      </m-dropdown-item>
+    </m-dropdown>
   </section>
 
   <section class='row'>
@@ -124,6 +133,11 @@
     <m-button class="my-button--disabled" title="Button disabled" disabled>Button disabled</m-button>
     <m-button>Icon button <m-icon type="regular" name="sheet"></m-icon></m-button>
     <m-button><m-icon type="bold" name="sheet"></m-icon> Icon button</m-button>
+  </section>
+
+  <section class='row'>
+    <h2>Button <span class='light-font'>Text</span></h2>
+    <m-button title="Button text" type="text">Button text</m-button>
   </section>
 
   <section class="row content-table">


### PR DESCRIPTION
- https://github.com/CESARBR/macaw/projects/1#card-49719590
- navbar: o uso do componente aberto no /docs estava com problemas, só faltando acrescentar aspas no atribute `active`

**m-button text**
<img width="193" alt="Screen Shot 2020-11-19 at 16 57 24" src="https://user-images.githubusercontent.com/15330412/99722751-e07e5e00-2a8f-11eb-8fd0-ff0d1d4ced13.png">

**m-dropdown com avatar**
<img width="128" alt="Screen Shot 2020-11-19 at 17 51 03" src="https://user-images.githubusercontent.com/15330412/99722756-e2e0b800-2a8f-11eb-98bc-cd349176cd1f.png">
