### PR TITLE
Macaw 0.2.1

### DIFF
--- a/docs/button.md
+++ b/docs/button.md
@@ -14,23 +14,24 @@ O `m-button` é o botão do Macaw. É possível desabilitá-lo ou adicionar um t
 
 <m-button class="my-button" title="Button default">Button</m-button>
 <m-button class="my-button--disabled" title="Button disabled" disabled>Button disabled</m-button>
-<m-button>Icon button <m-icon type="regular" name="sheet"></m-icon></m-button>
 <m-button><m-icon type="bold" name="sheet"></m-icon> Icon button</m-button>
+<m-button title="Button text" type="text">Button text</m-button>
 
 #### HTML
 ```html
 <m-button class="my-button" title="Button default">Button</m-button>
 <m-button class="my-button--disabled" title="Button disabled" disabled>Button disabled</m-button>
-<m-button>Icon button <m-icon type="regular" name="sheet"></m-icon></m-button>
 <m-button><m-icon type="bold" name="sheet"></m-icon> Icon button</m-button>
+<m-button title="Button text" type="text">Button text</m-button>
 ```
 
 ## Propriedades
 
-| Propriedade | Atributo   | Descrição          | Tipo      | Default     |
-| ----------- | ---------- | ------------------ | --------- | ----------- |
-| `disabled`  | `disabled` | Botão desabilitado | `boolean` | `false`     |
-| `tooltip`   | `title`    | Tooltip do botão   | `string`  | `undefined` |
+| Propriedade | Atributo   | Descrição                             | Tipo      | Default     |
+| ----------- | ---------- | ------------------------------------- | --------- | ----------- |
+| `disabled`  | `disabled` | Botão desabilitado                    | `boolean` | `false`     |
+| `tooltip`   | `title`    | Tooltip do botão                      | `string`  | `undefined` |
+| `type`      | -          | Tipo do botão (`primary` ou `text`)   | `string`  | `primary`   |
 
 
 ## Métodos

--- a/docs/dropdown.md
+++ b/docs/dropdown.md
@@ -35,9 +35,16 @@ O `m-dropdown` é o menu dropdown acompanhado por um `m-button`.
 
 ## Propriedades
 
-| Property | Attribute | Description             | Type     | Default     |
-| -------- | --------- | ----------------------- | -------- | ----------- |
-| `label`  | `label`   | Label do botão dropdown | `string` | `undefined` |
+| Propriedade           | Atributo             | Descrição                                                                                                                                       | Tipo      | Padrão                  |
+| ------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------------------------ |
+| `avatarSource`     | `avatar-source`       | URL da imagem do avatar ou o nome do usuário.                                                                                                     | `string`  | `undefined`              |
+| `dropdownButtonID` | `dropdown-button-i-d` | ID Unique.                                                                                                                                        | `string`  | `'mID-' + setUniqueID()` |
+| `icon`             | `icon`                | Ícone a ser exibido no botão                                                                                                                      | `string`  | `undefined`              |
+| `iconType`         | `icon-type`           | Tipo do Ícone ser exibido no botão                                                                                                                | `string`  | `undefined`              |
+| `label`            | `label`               | Etiqueta do dropdown                                                                                                                              | `string`  | `undefined`              |
+| `showChevron`      | `show-chevron`        | Se o ïcone de Chevron deve ser exibido                                                                                                            | `boolean` | `true`                   |
+| `showLabel`        | `show-label`          | Se a etiqueta do botão deve ser exibida. Caso seja usada uma imagem ou ícone é necessário fornecer o nome do botão, por motivos de acessibilidade | `boolean` | `true`                   |
+| `type`             | `type`                | Tipo do botão do Dropdown: `primary` ou `text`                                                                                                    | `string`  | `'primary'`              |
 
 
 ## Dependências

--- a/docs/menu-apps-item.md
+++ b/docs/menu-apps-item.md
@@ -13,12 +13,12 @@ O `m-menu-apps-item` é um componente de uso interno do `m-menu-apps` que trata 
 
 ## Propriedades
 
-| Property   | Attribute   | Description                           | Type     | Default     |
-| ---------- | ----------- | ------------------------------------- | -------- | ----------- |
-| `imgAlt`   | `img-alt`   | Menu item image alternate description | `string` | `undefined` |
-| `imgSrc`   | `img-src`   | Menu item image source                | `string` | `undefined` |
-| `itemName` | `item-name` | Menu item caption                     | `string` | `undefined` |
-| `link`     | `link`      | Menu item link                        | `string` | `undefined` |
+| Propriedades   | Atributo    | Descrição                                    | Tipo     | Padrão      |
+| -------------- | ----------- | -------------------------------------------- | -------- | ----------- |
+| `imgAlt`       | `img-alt`   | Descrição alternativa da imagem do Menu item | `string` | `undefined` |
+| `imgSrc`       | `img-src`   | URL da imagem do Menu item                   | `string` | `undefined` |
+| `itemName`     | `item-name` | Legenda do Menu Item                         | `string` | `undefined` |
+| `link`         | `link`      | Link do Menu item                            | `string` | `undefined` |
 
 
 ## Dependências

--- a/docs/menu-apps.md
+++ b/docs/menu-apps.md
@@ -10,180 +10,21 @@ permalink: menu-apps/
 
 O `m-menu-apps` é o componente de menu de aplicativos do Macaw.
 
-## Exemplo
+## Exemplos
 <style>
-  .m-menu-apps {
-    position: relative
+  m-menu-apps * {
+    box-sizing: initial;
   }
 
-  .m-menu-apps__button {
-    width: 32px;
-    height: 32px;
-    padding: 0;
-    border-radius: 4px;
-    border: none;
-    background-color: #F5F5F5;
-    outline: none
-  }
-
-  .m-menu-apps__icon {
-    display: inline-block;
-    margin: 10px 0 0 10px;
-    width: 12px;
-    height: 12px
-  }
-
-  .m-menu-apps__icon svg {
-    width: auto
-  }
-
-  .m-menu-apps .m-dropdown__content {
-    right: -30px;
-    left: unset;
-    max-height: 530px;
-    overflow-y: scroll
-  }
-
-  .m-menu-apps .m-dropdown__content .list-items {
-    padding: 0 8px;
-    min-width: unset
-  }
-
-  .m-menu-apps .m-dropdown__content .list-items hr {
-    width: calc(100% + 48px);
-    border-color: #D6D6D6;
-    border-style: solid;
-    border-bottom-width: 0;
-    border-top-width: 1px;
-    border-right-width: 0;
-    border-left-width: 0
-  }
-
-  .m-menu-apps .m-dropdown__content .list-items h3 {
-    width: 100%;
-    text-align: center;
-    font-weight: normal;
-    margin-top: 40px
-  }
-
-  .m-menu-apps.m-menu-apps-grid .m-dropdown__content .list-items {
-    display: flex;
-    flex-wrap: wrap;
-    max-width: 477px;
-    padding: 0 24px
-  }
-
-  .m-menu-apps.m-menu-apps-grid .m-dropdown__content .list-items hr {
-    width: calc(100% + 48px);
-    margin: 0 -24px 8px
-  }
-
-  .m-menu-apps.m-menu-apps-list .m-dropdown__content .list-items {
-    width: max-content
-  }
-
-  .m-menu-apps.m-menu-apps-list .m-dropdown__content .list-items hr {
-    width: calc(100% + 16px);
-    margin: 8px -8px
-  }
-
-  m-menu-apps-item {
-    margin-top: 8px;
-    display: block
-  }
-
-  m-menu-apps-item:last-child .m-menu-apps-item {
-    margin-bottom: 8px
-  }
-
-  m-menu-apps-item:hover .m-menu-apps-item {
-    background: #F5F5F5
-  }
-
-  m-menu-apps-item .m-menu-apps-item {
-    cursor: pointer;
-    border-radius: 5px
-  }
-
-  m-menu-apps-item a {
-    color: #4B4B4B;
-    text-decoration: none;
-    margin: 10px;
-    display: inline-block
-  }
-
-  m-menu-apps-item figure {
-    margin: 0;
-    padding: 0
-  }
-
-  m-menu-apps-item figure span {
-    display: flex;
-    align-items: center
-  }
-
-  m-menu-apps-item figure span img {
-    width: 100%;
-    height: auto
-  }
-
-  .m-menu-apps-grid .m-dropdown__content .list-items m-menu-apps-item {
-    margin-right: 31px;
-    margin-bottom: 8px;
-    height: 98px
-  }
-
-  .m-menu-apps-grid .m-dropdown__content .list-items m-menu-apps-item .m-menu-apps-item {
-    text-align: center;
-    width: 96px
-  }
-
-  .m-menu-apps-grid .m-dropdown__content .list-items m-menu-apps-item a {
-    display: inline-block
-  }
-
-  .m-menu-apps-grid .m-dropdown__content .list-items m-menu-apps-item figure span {
-    margin: 0 auto;
-    width: 56px;
-    height: 56px
-  }
-
-  .m-menu-apps-grid .m-dropdown__content .list-items m-menu-apps-item figure figcaption {
-    font-size: 0.625rem;
-    max-width: 76px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis
-  }
-
-  .m-menu-apps-grid .m-dropdown__content .list-items m-menu-apps-item:nth-of-type(4n) {
-    margin-right: 0
-  }
-
-  .m-menu-apps-grid .m-dropdown__content .list-items m-menu-apps-item:hover figure figcaption {
-    white-space: normal;
-    overflow: visible;
-    text-overflow: unset
-  }
-
-  .m-menu-apps-list .m-dropdown__content .list-items m-menu-apps-item figure {
-    display: flex;
-    align-items: center
-  }
-
-  .m-menu-apps-list .m-dropdown__content .list-items m-menu-apps-item figure span {
-    margin-right: 8px;
-    width: 32px;
-    height: 32px
-  }
-
-  .m-menu-apps-list .m-dropdown__content .list-items m-menu-apps-item figure figcaption {
-    font-size: 0.875rem
+  m-menu-apps-item .m-menu-apps-item a,
+  m-menu-apps-item .m-menu-apps-item a:hover {
+    background: none;
   }
 </style>
-
+### Menu de Aplicativos - tipo: Lista - itens carregados via JSON
 <m-menu-apps label="Menu de Aplicativos - Lista JSON" type="list" id="menu-items"></m-menu-apps>
 
+### Menu de Aplicativos - tipo: Lista - itens adicionados de forma declarativa
 <m-menu-apps label="Menu de Aplicativos - Lista" type="list">
   <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Intranet</m-menu-apps-item>
   <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Portal do Colaborador</m-menu-apps-item>
@@ -215,6 +56,7 @@ O `m-menu-apps` é o componente de menu de aplicativos do Macaw.
   <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Qlik Sense</m-menu-apps-item>
 </m-menu-apps>
 
+### Menu de Aplicativos - tipo: Grid - itens adicionados de forma declarativa
 <m-menu-apps label="Menu de Aplicativos - Grid" type="grid">
   <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Intranet</m-menu-apps-item>
   <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Portal do Colaborador</m-menu-apps-item>
@@ -252,7 +94,7 @@ O `m-menu-apps` é o componente de menu de aplicativos do Macaw.
 </script>
 
 ## Uso
-Existem três formas de instanciar o componente `<m-menu-apps>`:
+Existem duas formas de instanciar o componente `<m-menu-apps>`:
 ### 1. Tag simples e obtendo os itens via JSON
 HTML
 ```html
@@ -321,43 +163,26 @@ HTML
 ```html
 <m-menu-apps label="Menu de Aplicativos - Lista" type="list">
   <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Intranet</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Portal do Colaborador</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">SAI</m-menu-apps-item>
+  <!-- ... -->
   <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">HELP</m-menu-apps-item>
   <hr>
   <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Auxílio ao Idioma</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Baias</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Bens</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Biblioteca CESAR School</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">CODI</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">GIN</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Indique um Amigo</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Mapeamento de Competências</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Metas</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Papeleta de Viagem</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Punch Monitor</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">PrestContas</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Rateio</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Recrutador</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Solicitação de Evento</m-menu-apps-item>
+  <!-- ... -->
   <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Apps</m-menu-apps-item>
   <h3>Sistemas Parceiros</h3>
   <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">CRM</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Desko</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">HELP</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Portal do Colaborador</m-menu-apps-item>
-  <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Qulture Rocks</m-menu-apps-item>
+  <!-- ... -->
   <m-menu-apps-item link="http://" img-src="https://www.cesar.org.br/wp-content/uploads/2017/06/logo-md.png" img-alt="Marca CESAR">Qlik Sense</m-menu-apps-item>
 </m-menu-apps>
 ```
 
 ## Propriedades
 
-| Property        | Attribute         | Description              | Type     | Default     |
-| --------------- | ----------------- | ------------------------ | -------- | ----------- |
-| `label`         | `label`           | Menu label               | `string` | `undefined` |
-| `menuItemsJson` | `menu-items-json` | Menu Item items data.    | `string` | `undefined` |
-| `type`          | `type`            | Menu type (grid or list) | `string` | `'grid'`    |
+| Propriedades    | Atributo          | Descrição                                    | Tipo     | Padrão      |
+| --------------- | ----------------- | -------------------------------------------- | -------- | ----------- |
+| `label`         | `label`           | Etiqueta do Menu                             | `string` | `undefined` |
+| `menuItemsJson` | `menu-items-json` | Dados JSON com os dados dos itens do Menu    | `string` | `undefined` |
+| `type`          | `type`            | Tipo do Menu (grid ou list)                  | `string` | `'grid'`    |
 
 
 ### Depende de

--- a/src/components/m-dropdown/readme.md
+++ b/src/components/m-dropdown/readme.md
@@ -16,7 +16,7 @@
 | `label`            | `label`               | Dropdown label                                                                                                                                  | `string`  | `undefined`              |
 | `showChevron`      | `show-chevron`        | Whether to display the chevron icon or not                                                                                                      | `boolean` | `true`                   |
 | `showLabel`        | `show-label`          | Whether to display the button label or not. In case of using image or icon it's still need to provide a button label for accessibility reasons. | `boolean` | `true`                   |
-| `type`             | `type`                | Dropdown button type. "text" or "primary"                                                                                                       | `string`  | `'primary'`              |
+| `type`             | `type`                | Dropdown button type: `text` or `primary`                                                                                                       | `string`  | `'primary'`              |
 
 
 ## Dependencies

--- a/src/components/m-menu-apps-item/m-menu-apps-item.scss
+++ b/src/components/m-menu-apps-item/m-menu-apps-item.scss
@@ -25,6 +25,11 @@ m-menu-apps-item {
     text-decoration: none;
     margin: 10px;
     display: inline-block;
+    background: none;
+
+    &:hover {
+      background: none;
+    }
   }
 
   figure {

--- a/src/styles/vendors/_normalize.scss
+++ b/src/styles/vendors/_normalize.scss
@@ -6,8 +6,9 @@
 /* Document
    ========================================================================== */
 
-  * {
-  font-family: -apple-system, -apple-system-font, "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+* {
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji;
+  box-sizing: initial !important;
 }
 
 small {


### PR DESCRIPTION
## Macaw 0.2.1:
**Componentes:**
- Dropdown: acréscimo do type `text` (dessa forma já é permitido implementar o dropdown com avatar)
- Menu Apps (`m-menu-apps`): componente para exibição de ferramentas CESAR dentro do app-header

**Atualização**
- Atualizar links de guia de instalação do Macaw.
 